### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You must use fluentd 'Windows' brach to use me, and it doesn't work on Linux of 
 
     <source>
       type windows_eventlog
-      channel application,system
+      channels application,system
       pos_file c:\temp\mypos
       read_interval 2
       tag winevt.raw
@@ -26,7 +26,7 @@ You must use fluentd 'Windows' brach to use me, and it doesn't work on Linux of 
 
 |name      | description |
 |:-----    |:-----       |
-|channel   | (option) 'applicaion' as default. one or combination of {application, system, setup, security}. If you want to read setup or security, administrator priv is required to launch fluentd.  |
+|channels   | (option) 'applicaion' as default. one or combination of {application, system, setup, security}. If you want to read setup or security, administrator priv is required to launch fluentd.  |
 |pos_file  | (option, but higly recommended) a path of position file to save record numbers. |
 |read_interval   | (option) a read interval in second. 2 seconds as default.|
 |from_encoding  | (option) an input characters encoding. nil as default.|

--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ You must use fluentd 'Windows' brach to use me, and it doesn't work on Linux of 
       read_interval 2
       tag winevt.raw
     </source>
-    
+
 
 #### parameters
 
 |name      | description |
-|:-----    |:-----       |              
+|:-----    |:-----       |
 |channel   | (option) 'applicaion' as default. one or combination of {application, system, setup, security}. If you want to read setup or security, administrator priv is required to launch fluentd.  |
 |pos_file  | (option, but higly recommended) a path of position file to save record numbers. |
 |read_interval   | (option) a read interval in second. 2 seconds as default.|
+|from_encoding  | (option) an input characters encoding. nil as default.|
+|encoding   | (option) an output characters encoding. nil as default.|
 
 
 #### read keys

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-task :default => :test
+task default: :test

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_development_dependency "test-unit", "~> 3.2.0"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.11", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"
 end

--- a/lib/fluent/plugin/in_windows_eventlog.rb
+++ b/lib/fluent/plugin/in_windows_eventlog.rb
@@ -41,7 +41,7 @@ module Fluent::Plugin
       super
       @chs = @channels.map {|ch| ch.strip.downcase }.uniq
       if @chs.empty?
-        raise Fluent::ConfigError, "winevtlog: 'channels' parameter is required on winevtlog input"
+        raise Fluent::ConfigError, "windows_eventlog: 'channels' parameter is required on windows_eventlog input"
       end
       @keynames = @keys.map {|k| k.strip }.uniq
       if @keynames.empty?
@@ -60,7 +60,7 @@ module Fluent::Plugin
     def configure_encoding
       unless @encoding
         if @from_encoding
-          raise Fluent::ConfigError, "winevtlog: 'from_encoding' parameter must be specied with 'encoding' parameter."
+          raise Fluent::ConfigError, "windows_eventlog: 'from_encoding' parameter must be specied with 'encoding' parameter."
         end
       end
 

--- a/lib/fluent/plugin/in_windows_eventlog.rb
+++ b/lib/fluent/plugin/in_windows_eventlog.rb
@@ -22,8 +22,8 @@ module Fluent::Plugin
     config_param :tag, :string
     config_param :read_interval, :time, default: 2
     config_param :pos_file, :string, default: nil
-    config_param :channel, :string, default: 'Application'
-    config_param :key, :string, default: ''
+    config_param :channels, :array, default: ['Application']
+    config_param :keys, :string, default: []
     config_param :read_from_head, :bool, default: false
     config_param :from_encoding, :string, default: nil
     config_param :encoding, :string, default: nil
@@ -39,11 +39,11 @@ module Fluent::Plugin
 
     def configure(conf)
       super
-      @chs = @channel.split(',').map {|ch| ch.strip.downcase }.uniq
+      @chs = @channels.map {|ch| ch.strip.downcase }.uniq
       if @chs.empty?
-        raise Fluent::ConfigError, "winevtlog: 'channel' parameter is required on winevtlog input"
+        raise Fluent::ConfigError, "winevtlog: 'channels' parameter is required on winevtlog input"
       end
-      @keynames = @key.split(',').map {|k| k.strip }.uniq
+      @keynames = @keys.map {|k| k.strip }.uniq
       if @keynames.empty?
         @keynames = KEY_MAP.keys
       end

--- a/lib/fluent/plugin/in_windows_eventlog.rb
+++ b/lib/fluent/plugin/in_windows_eventlog.rb
@@ -8,7 +8,7 @@ module Fluent::Plugin
 
     helpers :timer
 
-    @@KEY_MAP = {"record_number" => :record_number,
+    KEY_MAP = {"record_number" => :record_number,
                  "time_generated" => :time_generated,
                  "time_written" => :time_written,
                  "event_id" => :event_id,
@@ -45,7 +45,7 @@ module Fluent::Plugin
       end
       @keynames = @key.split(',').map {|k| k.strip }.uniq
       if @keynames.empty?
-        @keynames = @@KEY_MAP.keys
+        @keynames = KEY_MAP.keys
       end
       @tag = tag
       @stop = false
@@ -149,8 +149,8 @@ module Fluent::Plugin
       begin
         for r in lines
           h = {"channel" => ch}
-          @keynames.each {|k| h[k]=@receive_handlers.call(r.send(@@KEY_MAP[k]).to_s)}
-          #h = Hash[@keynames.map {|k| [k, r.send(@@KEY_MAP[k]).to_s]}]
+          @keynames.each {|k| h[k]=@receive_handlers.call(r.send(KEY_MAP[k]).to_s)}
+          #h = Hash[@keynames.map {|k| [k, r.send(KEY_MAP[k]).to_s]}]
           router.emit(@tag, Fluent::Engine.now, h)
           pe[1] +=1
         end

--- a/lib/fluent/plugin/in_windows_eventlog.rb
+++ b/lib/fluent/plugin/in_windows_eventlog.rb
@@ -20,13 +20,13 @@ module Fluent::Plugin
                  "description" => :description}
 
     config_param :tag, :string
-    config_param :read_interval, :time, :default => 2
-    config_param :pos_file, :string, :default => nil
-    config_param :channel, :string, :default => 'Application'
-    config_param :key, :string, :default => ''
-    config_param :read_from_head, :bool, :default => false
-    config_param :from_encoding, :string, :default => nil
-    config_param :encoding, :string, :default => nil
+    config_param :read_interval, :time, default: 2
+    config_param :pos_file, :string, default: nil
+    config_param :channel, :string, default: 'Application'
+    config_param :key, :string, default: ''
+    config_param :read_from_head, :bool, default: false
+    config_param :from_encoding, :string, default: nil
+    config_param :encoding, :string, default: nil
 
     attr_reader :chs
 
@@ -155,7 +155,7 @@ module Fluent::Plugin
           pe[1] +=1
         end
       rescue
-        $log.error "unexpected error", :error=>$!.to_s
+        $log.error "unexpected error", error: $!.to_s
         $log.error_backtrace
       end
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,7 +22,8 @@ unless ENV.has_key?('VERBOSE')
   $log = nulllogger
 end
 
-require 'fluent/plugin/in_winevtlog'
+require 'fluent/test/driver/input'
+require 'fluent/plugin/in_windows_eventlog'
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_in_winevtlog.rb
+++ b/test/plugin/test_in_winevtlog.rb
@@ -1,31 +1,26 @@
 require 'helper'
 
-class WinEvtLogTest < Test::Unit::TestCase
+class WindowsEventLogInputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
   end
 
   CONFIG = %[
+    tag fluent.eventlog
   ]
-  # CONFIG = %[
-  #   path #{TMP_DIR}/out_file_test
-  #   compress gz
-  #   utc
-  # ]
 
-  def create_driver(conf = CONFIG, tag='test')
-    Fluent::Test::InputTestDriver.new(Fluent::WinEvtLog).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::WindowsEventLogInput).configure(conf)
   end
 
   def test_configure
-    #### set configurations
-    # d = create_driver %[
-    #   path test_path
-    #   compress gz
-    # ]
-    #### check configurations
-    # assert_equal 'test_path', d.instance.path
-    # assert_equal :gz, d.instance.compress
+    d = create_driver CONFIG
+    assert_equal 'fluent.eventlog', d.instance.tag
+    assert_equal 2, d.instance.read_interval
+    assert_nil d.instance.pos_file
+    assert_equal 'Application', d.instance.channel
+    assert_true d.instance.key.empty?
+    assert_false d.instance.read_from_head
   end
 
   def test_format

--- a/test/plugin/test_in_winevtlog.rb
+++ b/test/plugin/test_in_winevtlog.rb
@@ -18,8 +18,8 @@ class WindowsEventLogInputTest < Test::Unit::TestCase
     assert_equal 'fluent.eventlog', d.instance.tag
     assert_equal 2, d.instance.read_interval
     assert_nil d.instance.pos_file
-    assert_equal 'Application', d.instance.channel
-    assert_true d.instance.key.empty?
+    assert_equal ['Application'], d.instance.channels
+    assert_true d.instance.keys.empty?
     assert_false d.instance.read_from_head
   end
 


### PR DESCRIPTION
I've tested with the following config:

```log
<source>
    @type windows_eventlog
    channels ["Application"]
    pos_file "C:\\Users\\<my account username>\\AppData\\Local\\Temp\\mypos"
    read_interval 1
    tag "winevt.raw"
    read_from_head true
    from_encoding "SHIFT_JIS"
    encoding "UTF-8"
  </source>
  <match **>
    @type stdout
  </match>
```

Output:

```log
2017-01-19 15:25:51.686069000 +0900 winevt.raw: {"channel":"application","record_number":"13346","time_generated":"2017-01-19 13:49:30 +0900","time_written":"2017-01-19 13:49:30 +0900","event_id":"258","event_type":"information","event_category":"0","source_name":"Microsoft-Windows-Defrag","computer_name":"LAPTOP-2KFM0IP4","user":"","description":"ストレージ最適化ツールは (C:) の 最適化 を完了しました\r\n"}
2017-01-19 15:25:51.686069000 +0900 winevt.raw: {"channel":"application","record_number":"13347","time_generated":"2017-01-19 13:49:32 +0900","time_written":"2017-01-19 13:49:32 +0900","event_id":"258","event_type":"information","event_category":"0","source_name":"Microsoft-Windows-Defrag","computer_name":"LAPTOP-2KFM0IP4","user":"","description":"ストレージ最適化ツールは Windows RE tools の 最適化 を完了しました\r\n"}
2017-01-19 15:25:51.686069000 +0900 winevt.raw: {"channel":"application","record_number":"13348","time_generated":"2017-01-19 13:52:51 +0900","time_written":"2017-01-19 13:52:51 +0900","event_id":"8224","event_type":"information","event_category":"0","source_name":"VSS","computer_name":"LAPTOP-2KFM0IP4","user":"","description":"アイドル タイムアウトにより VSS サービスをシャットダウンしています。\r\n\r\n"}
```