### PR TITLE
Use Ruby 2.4 and 2.3 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,11 @@ version: '{build}'
 
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - IF %ridk%==0 "%devkit%\\devkitvars.bat"
   - ruby --version
   - gem --version
-  - ridk.cmd exec bundle install
+  - IF %ridk%==1 ridk.cmd exec bundle install
+  - IF %ridk%==0 bundle install
 build: off
 test_script:
   - bundle exec rake test
@@ -20,5 +22,13 @@ branches:
 # https://www.appveyor.com/docs/installed-software/#ruby
 environment:
   matrix:
+    - ruby_version: "23-x64"
+      devkit: C:\Ruby23-x64\DevKit
+      ridk: 0
+    - ruby_version: "23"
+      devkit: C:\Ruby23\DevKit
+      ridk: 0
     - ruby_version: "24-x64"
+      ridk: 1
     - ruby_version: "24"
+      ridk: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,9 @@ version: '{build}'
 
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - "%devkit%\\devkitvars.bat"
   - ruby --version
   - gem --version
-  - bundle install
+  - ridk.cmd exec bundle install
 build: off
 test_script:
   - bundle exec rake test
@@ -21,7 +20,5 @@ branches:
 # https://www.appveyor.com/docs/installed-software/#ruby
 environment:
   matrix:
-    - ruby_version: "23-x64"
-      devkit: C:\Ruby23-x64\DevKit
-    - ruby_version: "23"
-      devkit: C:\Ruby23\DevKit
+    - ruby_version: "24-x64"
+    - ruby_version: "24"


### PR DESCRIPTION
AppVeyor supports Ruby 2.4: appveyor/ci#1350
Now, we can switch to use Ruby 2.4 in AppVeyor.
td-agent 3 will ship with Ruby 2.4.
So, we should use Ruby 2.4 instead of 2.3 in CI.