### PR TITLE
Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [Fluentd](http://fluentd.org) plugin to read the Windows Event Log.
 
 ## Installation
-    gem install fluent-plugin-windows-eventlog
+    ridk exec gem install fluent-plugin-windows-eventlog
 
 ## Configuration
 


### PR DESCRIPTION
Because we need to run gcc and g++ during winevt_c gem's installation

Related to #22.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>