### PR TITLE
Optimize events handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       channels application,system
       read_interval 2
       tag winevt.raw
+      render_as_xml false       # default is true.
+      rate_limit 200            # default is -1(Winevt::EventLog::Subscribe::RATE_INFINITE).
       <storage>
         @type local             # @type local is the default.
         persistent true         # default is true. Set to false to use in-memory storage.
@@ -152,6 +154,10 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 **NOTE:** in_windows_eventlog2 always handles EventLog records as UTF-8 characters. Users don't have to specify encoding related parameters and they are not provided.
 
 **NOTE:** When `Description` contains error message such as `The message resource is present but the message was not found in the message table.`, eventlog's resource file (.mui) related to error generating event is something wrong. This issue is also occurred in built-in Windows Event Viewer which is the part of Windows management tool.
+
+**NOTE:** When `render_as_xml` as `false`, the dependent winevt_c gem renders Windows EventLog as Ruby Hash object directly. This reduces bottleneck to consume EventLog. Specifying `render_as_xml` as `false` should be faster consuming than `render_as_xml` as `true` case.
+
+**NOTE:** If you encountered CPU spike due to massively huge EventLog channel, `rate_limit` parameter may help you. Currently, this paramter can handle the multiples of 10 or -1(`Winevt::EventLog::Subscribe::RATE_INFINITE`).
 
 #### parameters
 

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.2.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"
-  spec.add_runtime_dependency "winevt_c"
+  spec.add_runtime_dependency "winevt_c", ">= 0.6.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.10"
 end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -36,6 +36,7 @@ module Fluent::Plugin
     config_param :read_from_head, :bool, default: false
     config_param :parse_description, :bool, default: false
     config_param :render_as_xml, :bool, default: true
+    config_param :rate_limit, :integer, default: Winevt::EventLog::Subscribe::RATE_INFINITE
 
     config_section :storage do
       config_set_default :usage, "bookmarks"
@@ -89,6 +90,7 @@ module Fluent::Plugin
         subscribe.tail = @tailing
         subscribe.subscribe(ch, "*", bookmark)
         subscribe.render_as_xml = @render_as_xml
+        subscribe.rate_limit = @rate_limit
         timer_execute("in_windows_eventlog_#{escape_channel(ch)}".to_sym, @read_interval) do
           on_notify(ch, subscribe)
         end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -35,6 +35,7 @@ module Fluent::Plugin
     config_param :keys, :array, default: []
     config_param :read_from_head, :bool, default: false
     config_param :parse_description, :bool, default: false
+    config_param :render_as_xml, :bool, default: true
 
     config_section :storage do
       config_set_default :usage, "bookmarks"
@@ -60,12 +61,22 @@ module Fluent::Plugin
       if @keynames.empty?
         @keynames = KEY_MAP.keys
       end
+      @keynames.delete('Qualifiers') unless @render_as_xml
       @keynames.delete('EventData') if @parse_description
 
       @tag = tag
       @tailing = @read_from_head ? false : true
       @bookmarks_storage = storage_create(usage: "bookmarks")
-      @parser = parser_create
+      if @render_as_xml
+        @parser = parser_create
+        class << self
+          alias_method :on_notify, :on_notify_xml
+        end
+      else
+        class << self
+          alias_method :on_notify, :on_notify_hash
+        end
+      end
     end
 
     def start
@@ -77,6 +88,7 @@ module Fluent::Plugin
         bookmark = Winevt::EventLog::Bookmark.new(bookmarkXml)
         subscribe.tail = @tailing
         subscribe.subscribe(ch, "*", bookmark)
+        subscribe.render_as_xml = @render_as_xml
         timer_execute("in_windows_eventlog_#{escape_channel(ch)}".to_sym, @read_interval) do
           on_notify(ch, subscribe)
         end
@@ -88,6 +100,10 @@ module Fluent::Plugin
     end
 
     def on_notify(ch, subscribe)
+      # for safety.
+    end
+
+    def on_notify_xml(ch, subscribe)
       es = Fluent::MultiEventStream.new
       subscribe.each do |xml, message, string_inserts|
         @parser.parse(xml) do |time, record|
@@ -116,6 +132,31 @@ module Fluent::Plugin
             es.add(Fluent::Engine.now, record)
           end
         end
+      end
+      router.emit_stream(@tag, es)
+      @bookmarks_storage.put(ch, subscribe.bookmark)
+    end
+
+    def on_notify_hash(ch, subscribe)
+      es = Fluent::MultiEventStream.new
+      subscribe.each do |record, message, string_inserts|
+        record["Description"] = message
+        record["EventData"] = string_inserts
+        h = {}
+        @keynames.each do |k|
+          type = KEY_MAP[k][1]
+          value = record[KEY_MAP[k][0]]
+          h[k]=case type
+               when :string
+                 value.to_s
+               when :array
+                 value.map {|v| v.to_s}
+               else
+                 raise "Unknown value type: #{type}"
+               end
+        end
+        parse_desc(h) if @parse_description
+        es.add(Fluent::Engine.now, h)
       end
       router.emit_stream(@tag, es)
       @bookmarks_storage.put(ch, subscribe.bookmark)


### PR DESCRIPTION
Related to #20.

* If `render_as_xml` is false, winevt_c renders as Ruby Hash object directly instead of render XML string.
* Support rate limit feature