### PR TITLE
Handle privileges record on #parse_desc

### DIFF
--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -225,6 +225,8 @@ module Fluent::Plugin
               record[k] = value
             end
           end
+          # XXX: This is for empty privileges record key.
+          # We should investigate whether an another case exists or not.
           previous_key = to_key(key) unless key.empty?
         }
       }

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -200,6 +200,7 @@ module Fluent::Plugin
 
       elems = desc.split(GROUP_DELIMITER)
       record['DescriptionTitle'] = elems.shift
+      previous_key = nil
       elems.each { |elem|
         parent_key = nil
         elem.split(RECORD_DELIMITER).each { |r|
@@ -214,13 +215,17 @@ module Fluent::Plugin
           else
             # parsed value sometimes contain unexpected "\t". So remove it.
             value.strip!
-            if parent_key.nil?
+            # merge empty key values into the previous non-empty key record.
+            if key.empty?
+              record[previous_key] = [record[previous_key], value].flatten
+            elsif parent_key.nil?
               record[to_key(key)] = value
             else
               k = "#{parent_key}.#{to_key(key)}"
               record[k] = value
             end
           end
+          previous_key = key unless key.empty?
         }
       }
     end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -225,7 +225,7 @@ module Fluent::Plugin
               record[k] = value
             end
           end
-          previous_key = key unless key.empty?
+          previous_key = to_key(key) unless key.empty?
         }
       }
     end

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -48,6 +48,33 @@ DESC
     assert_equal(expected, h)
   end
 
+  def test_parse_privileges_description
+    d = create_driver
+    desc = <<-DESC
+Special privileges assigned to new logon.\r\n\r\nSubject:\r\n\tSecurity ID:\t\tS-X-Y-ZZ\r\n\tAccountName:\t\tSYSTEM\r\n\tAccount Domain:\t\tNT AUTHORITY\r\n\tLogon ID:\t\t0x3E7\r\n\r\nPrivileges:\t\tSeAssignPrimaryTokenPrivilege\r\n\t\t\tSeTcbPrivilege\r\n\t\t\tSeSecurityPrivilege\r\n\t\t\tSeTakeOwnershipPrivilege\r\n\t\t\tSeLoadDriverPrivilege\r\n\t\t\tSeBackupPrivilege\r\n\t\t\tSeRestorePrivilege\r\n\t\t\tSeDebugPrivilege\r\n\t\t\tSeAuditPrivilege\r\n\t\t\tSeSystemEnvironmentPrivilege\r\n\t\t\tSeImpersonatePrivilege\r\n\t\t\tSeDelegateSessionUserImpersonatePrivilege"
+DESC
+    h = {"Description" => desc}
+    expected = {"DescriptionTitle"       => "Special privileges assigned to new logon.",
+                "subject.security_id"    => "S-X-Y-ZZ",
+                "subject.accountname"    => "SYSTEM",
+                "subject.account_domain" => "NT AUTHORITY",
+                "subject.logon_id"       => "0x3E7",
+                "privileges"             => ["SeAssignPrimaryTokenPrivilege",
+                                             "SeTcbPrivilege",
+                                             "SeSecurityPrivilege",
+                                             "SeTakeOwnershipPrivilege",
+                                             "SeLoadDriverPrivilege",
+                                             "SeBackupPrivilege",
+                                             "SeRestorePrivilege",
+                                             "SeDebugPrivilege",
+                                             "SeAuditPrivilege",
+                                             "SeSystemEnvironmentPrivilege",
+                                             "SeImpersonatePrivilege",
+                                             "SeDelegateSessionUserImpersonatePrivilege\""]}
+    d.instance.parse_desc(h)
+    assert_equal(expected, h)
+  end
+
   def test_write
     d = create_driver
 

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -50,9 +50,14 @@ DESC
 
   def test_parse_privileges_description
     d = create_driver
-    desc = <<-DESC
-Special privileges assigned to new logon.\r\n\r\nSubject:\r\n\tSecurity ID:\t\tS-X-Y-ZZ\r\n\tAccountName:\t\tSYSTEM\r\n\tAccount Domain:\t\tNT AUTHORITY\r\n\tLogon ID:\t\t0x3E7\r\n\r\nPrivileges:\t\tSeAssignPrimaryTokenPrivilege\r\n\t\t\tSeTcbPrivilege\r\n\t\t\tSeSecurityPrivilege\r\n\t\t\tSeTakeOwnershipPrivilege\r\n\t\t\tSeLoadDriverPrivilege\r\n\t\t\tSeBackupPrivilege\r\n\t\t\tSeRestorePrivilege\r\n\t\t\tSeDebugPrivilege\r\n\t\t\tSeAuditPrivilege\r\n\t\t\tSeSystemEnvironmentPrivilege\r\n\t\t\tSeImpersonatePrivilege\r\n\t\t\tSeDelegateSessionUserImpersonatePrivilege"
-DESC
+    desc = ["Special privileges assigned to new logon.\r\n\r\nSubject:\r\n\tSecurity ID:\t\tS-X-Y-ZZ\r\n\t",
+            "AccountName:\t\tSYSTEM\r\n\tAccount Domain:\t\tNT AUTHORITY\r\n\tLogon ID:\t\t0x3E7\r\n\r\n",
+            "Privileges:\t\tSeAssignPrimaryTokenPrivilege\r\n\t\t\tSeTcbPrivilege\r\n\t\t\t",
+            "SeSecurityPrivilege\r\n\t\t\tSeTakeOwnershipPrivilege\r\n\t\t\tSeLoadDriverPrivilege\r\n\t\t\t",
+            "SeBackupPrivilege\r\n\t\t\tSeRestorePrivilege\r\n\t\t\tSeDebugPrivilege\r\n\t\t\t",
+            "SeAuditPrivilege\r\n\t\t\tSeSystemEnvironmentPrivilege\r\n\t\t\tSeImpersonatePrivilege\r\n\t\t\t",
+            "SeDelegateSessionUserImpersonatePrivilege"].join("")
+
     h = {"Description" => desc}
     expected = {"DescriptionTitle"       => "Special privileges assigned to new logon.",
                 "subject.security_id"    => "S-X-Y-ZZ",
@@ -70,7 +75,7 @@ DESC
                                              "SeAuditPrivilege",
                                              "SeSystemEnvironmentPrivilege",
                                              "SeImpersonatePrivilege",
-                                             "SeDelegateSessionUserImpersonatePrivilege\""]}
+                                             "SeDelegateSessionUserImpersonatePrivilege"]}
     d.instance.parse_desc(h)
     assert_equal(expected, h)
   end


### PR DESCRIPTION
Fixes https://github.com/fluent/fluent-plugin-windows-eventlog/issues/30

Currently, parsing privileges record in Description generates empty key record.
This PR fixes dropping privileges information when using `parse_description true`.
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>