### PR TITLE
Add key if key is nil

### DIFF
--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -209,6 +209,7 @@ module Fluent::Plugin
                        else
                          r.split(NONE_FIELD_DELIMITER)
                        end
+          key = "" if key.nil?
           key.chop!  # remove ':' from key
           if value.nil?
             parent_key = to_key(key)
@@ -217,7 +218,7 @@ module Fluent::Plugin
             value.strip!
             # merge empty key values into the previous non-empty key record.
             if key.empty?
-              record[previous_key] = [record[previous_key], value].flatten
+              record[previous_key] = [record[previous_key], value].flatten.reject {|e| e.nil?}
             elsif parent_key.nil?
               record[to_key(key)] = value
             else


### PR DESCRIPTION
Adding a key if there is none, will fix https://github.com/fluent/fluent-plugin-windows-eventlog/issues/36

![image](https://user-images.githubusercontent.com/4808216/73176409-ac0a7180-410c-11ea-85db-aac21ac71c37.png)
These lines had no key and would break at `key.chop!`

and removes null from record where its not supposed to be. Thanks to @cosmo0920 for that change in https://github.com/fluent/fluent-plugin-windows-eventlog/pull/37




