### PR TITLE
in_windows_eventlog2: Loosen escaping character target

### DIFF
--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -109,7 +109,7 @@ module Fluent::Plugin
     end
 
     def escape_channel(ch)
-      ch.gsub(/[^a-zA-Z0-9]/, '_')
+      ch.gsub(/[^a-zA-Z0-9\s]/, '_')
     end
 
     def on_notify(ch, subscribe)

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -28,6 +28,16 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
     assert_true d.instance.render_as_xml
   end
 
+  data("application"        => ["Application", "Application"],
+       "windows powershell" => ["Windows PowerShell", "Windows PowerShell"],
+       "escaped"            => ["Should_Be_Escaped_", "Should+Be;Escaped/"]
+      )
+  def test_escape_channel(data)
+    expected, actual = data
+    d = create_driver CONFIG
+    assert_equal expected, d.instance.escape_channel(actual)
+  end
+
   def test_parse_desc
     d = create_driver
     desc =<<-DESC


### PR DESCRIPTION
Fixes #24 

Because `Windows PowerShell`, `Directory Service`, and other channels should be
included a space.
We should these channel names should be treated as valid channel.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>