### PR TITLE
Support subscribe directive to handle read_existing_events paratemer each of channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`from_encoding`    | (option) Input character encoding. `nil` as default.|
 |`<storage>`        | Setting for `storage` plugin for recording read position like `in_tail`'s `pos_file`.|
 |`<parse>`          | Setting for `parser` plugin for parsing raw XML EventLog records. |
+|`parse_description`| (option) parse `description` field and set parsed result into the record. `Description` and `EventData` fields are removed|
 |`read_from_head`   | **Deprecated** (option) Start to read the entries from the oldest, not from when fluentd is started. Defaults to `false`.|
 |`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|
 |`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
     <source>
       @type windows_eventlog2
       @id windows_eventlog2
-      channels application,system
+      channels application,system # Also be able to use `<subscribe>` directive.
+      read_existing_events false
       read_interval 2
       tag winevt.raw
       render_as_xml false       # default is true.
@@ -149,6 +150,10 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       <parse>
         @type winevt_xml # @type winevt_xml is the default. winevt_xml and none parsers are supported for now.
       </parse>
+      # <subscribe>
+      #   channles application, system
+      #   read_existing_events false # read_existing_events should be applied each of subscribe directive(s)
+      # </subscribe>
     </source>
 
 **NOTE:** in_windows_eventlog2 always handles EventLog records as UTF-8 characters. Users don't have to specify encoding related parameters and they are not provided.
@@ -169,7 +174,53 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`from_encoding`    | (option) Input character encoding. `nil` as default.|
 |`<storage>`        | Setting for `storage` plugin for recording read position like `in_tail`'s `pos_file`.|
 |`<parse>`          | Setting for `parser` plugin for parsing raw XML EventLog records. |
-|`parse_description`| (option) parse `description` field and set parsed result into the record. `Description` and `EventData` fields are removed|
+|`read_from_head`   | **Deprecated** (option) Start to read the entries from the oldest, not from when fluentd is started. Defaults to `false`.|
+|`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|
+|`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|
+|`rate_limit`      | (option) Specify rate limit to consume EventLog. Default is `Winevt::EventLog::Subscribe::RATE_INFINITE`.|
+|`<subscribe>`          | Setting for subscribe channels. |
+
+##### subscribe section
+
+|name      | description |
+|:-----    |:-----       |
+|`channels`             | One or more of {'application', 'system', 'setup', 'security'}. If you want to read 'setup' or 'security' logs, you must launch fluentd with administrator privileges. |
+|`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`. |
+
+
+**Motivation:** subscribe directive is designed for applying `read_existing_events` each of channels which is specified in subscribe section(s).
+
+e.g) The previous configuration can handle `read_existing_events` but this parameter only specifies `read_existing_events` or not for channels which are specified in `channels`.
+
+```aconf
+channels ["Application", "Security", "HardwareEvents"]
+read_existing_events true
+```
+
+is interpreted as "Application", "Security", and "HardwareEvents" should be read existing events.
+
+But some users want to configure to:
+
+* "Application" and "Security" channels just tailing
+* "HardwareEvent" channel read existing events before launching Fluentd
+
+With `<subscribe>` directive, this requirements can be represendted as:
+
+```aconf
+<subscribe>
+  channles ["Application", "Security"]
+  # read_existing_events false
+</subscribe>
+<subscribe>
+  channles ["HardwareEvent"]
+  read_existing_events true
+</subscribe>
+```
+
+This configuration can be handled as:
+
+* "Application" and "Security" channels just tailing
+* "HardwareEvent" channel read existing events before launching Fluentd
 
 ##### Available keys
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 
 |name      | description |
 |:-----    |:-----       |
-|`channels`         | (option) 'application' as default. One or more of {'application', 'system', 'setup', 'security'}. If you want to read 'setup' or 'security' logs, you must launch fluentd with administrator privileges.|
+|`channels`         | (option) No default value just empty array, but 'application' is used as default due to backward compatibility. One or more of {'application', 'system', 'setup', 'security'}. If you want to read 'setup' or 'security' logs, you must launch fluentd with administrator privileges.|
 |`keys`             | (option) A subset of [keys](#read-keys) to read. Defaults to all keys.|
 |`read_interval`    | (option) Read interval in seconds. 2 seconds as default.|
 |`from_encoding`    | (option) Input character encoding. `nil` as default.|

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.2.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"
-  spec.add_runtime_dependency "winevt_c", [">= 0.6.1", "< 0.7.0"]
+  spec.add_runtime_dependency "winevt_c", ">= 0.7.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.10"
   spec.add_runtime_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
 end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -107,11 +107,11 @@ module Fluent::Plugin
       super
 
       @chs.each do |ch, read_existing_events|
-        subscribe_channels(ch, read_existing_events)
+        subscribe_channel(ch, read_existing_events)
       end
     end
 
-    def subscribe_channels(ch, read_existing_events)
+    def subscribe_channel(ch, read_existing_events)
       bookmarkXml = @bookmarks_storage.get(ch) || ""
       subscribe = Winevt::EventLog::Subscribe.new
       bookmark = unless bookmarkXml.empty?

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -64,6 +64,29 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
                                                         }),
                                        ])
       expected = [["system", false], ["windows powershell", false], ["security", true]]
+      assert_equal 1, d.instance.instance_variable_get(:@chs).select {|ch, flag| ch == "system"}.size
+      assert_equal expected, d.instance.instance_variable_get(:@chs)
+    end
+
+    test "non duplicated subscribe" do
+      d = create_driver config_element("ROOT", "", {"tag" => "fluent.eventlog",
+                                                    "channels" => ["System", "Windows PowerShell"]
+                                                   }, [
+                                         config_element("storage", "", {
+                                                          '@type' => 'local',
+                                                          'persistent' => false
+                                                        }),
+                                         config_element("subscribe", "", {
+                                                          'channels' => ['System', 'Windows PowerShell'],
+                                                          'read_existing_events' => true
+                                                        }),
+                                         config_element("subscribe", "", {
+                                                          'channels' => ['Security'],
+                                                          'read_existing_events' => true
+                                                        }),
+                                       ])
+      expected = [["system", false], ["windows powershell", false], ["system", true], ["windows powershell", true], ["security", true]]
+      assert_equal 2, d.instance.instance_variable_get(:@chs).select {|ch, flag| ch == "system"}.size
       assert_equal expected, d.instance.instance_variable_get(:@chs)
     end
   end

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -28,6 +28,46 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
     assert_true d.instance.render_as_xml
   end
 
+  sub_test_case "configure" do
+    test "subscribe directive" do
+      d = create_driver config_element("ROOT", "", {"tag" => "fluent.eventlog"}, [
+                                         config_element("storage", "", {
+                                                          '@type' => 'local',
+                                                          'persistent' => false
+                                                        }),
+                                         config_element("subscribe", "", {
+                                                          'channels' => ['System', 'Windows PowerShell'],
+                                                        }),
+                                         config_element("subscribe", "", {
+                                                          'channels' => ['Security'],
+                                                          'read_existing_events' => true
+                                                        }),
+                                       ])
+      expected = [["system", false], ["windows powershell", false], ["security", true]]
+      assert_equal expected, d.instance.instance_variable_get(:@chs)
+    end
+
+    test "duplicated subscribe" do
+      d = create_driver config_element("ROOT", "", {"tag" => "fluent.eventlog",
+                                                    "channels" => ["System", "Windows PowerShell"]
+                                                   }, [
+                                         config_element("storage", "", {
+                                                          '@type' => 'local',
+                                                          'persistent' => false
+                                                        }),
+                                         config_element("subscribe", "", {
+                                                          'channels' => ['System', 'Windows PowerShell'],
+                                                        }),
+                                         config_element("subscribe", "", {
+                                                          'channels' => ['Security'],
+                                                          'read_existing_events' => true
+                                                        }),
+                                       ])
+      expected = [["system", false], ["windows powershell", false], ["security", true]]
+      assert_equal expected, d.instance.instance_variable_get(:@chs)
+    end
+  end
+
   data("application"        => ["Application", "Application"],
        "windows powershell" => ["Windows PowerShell", "Windows PowerShell"],
        "escaped"            => ["Should_Be_Escaped_", "Should+Be;Escaped/"]

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -24,7 +24,7 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
     assert_equal 'fluent.eventlog', d.instance.tag
     assert_equal 2, d.instance.read_interval
     assert_equal ['application'], d.instance.channels
-    assert_false d.instance.read_from_head
+    assert_false d.instance.read_existing_events
     assert_true d.instance.render_as_xml
   end
 

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -23,7 +23,7 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
     d = create_driver CONFIG
     assert_equal 'fluent.eventlog', d.instance.tag
     assert_equal 2, d.instance.read_interval
-    assert_equal ['application'], d.instance.channels
+    assert_equal [], d.instance.channels
     assert_false d.instance.read_existing_events
     assert_true d.instance.render_as_xml
   end


### PR DESCRIPTION
Because some channels are empty when starting Fluentd.
`<subscribe>` directive can apply `read_existing_events` separately.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>