### PR TITLE
Add empty bookmark checking mechanism

### DIFF
--- a/lib/fluent/plugin/bookmark_sax_parser.rb
+++ b/lib/fluent/plugin/bookmark_sax_parser.rb
@@ -1,0 +1,30 @@
+require 'nokogiri'
+
+class WinevtBookmarkDocument < Nokogiri::XML::SAX::Document
+  attr_reader :result
+
+  def initialize
+    @result = {}
+    super
+  end
+
+  def start_document
+  end
+
+  def start_element(name, attributes = [])
+    if name == "Bookmark"
+      @result[:channel] = attributes[0][1] rescue nil
+      @result[:record_id] = attributes[1][1].to_i rescue nil
+      @result[:is_current] = attributes[2][1].downcase == "true" rescue nil
+    end
+  end
+
+  def characters(string)
+  end
+
+  def end_element(name, attributes = [])
+  end
+
+  def end_document
+  end
+end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -139,10 +139,10 @@ module Fluent::Plugin
       parser = Nokogiri::XML::SAX::Parser.new(evtxml)
       parser.parse(bookmarkXml)
       result = evtxml.result
-      if !result.empty? && (result[:channel] == channel) && result[:is_current]
+      if !result.empty? && (result[:channel].downcase == channel.downcase) && result[:is_current]
         true
       else
-        log.warn "This stored bookmark is incomplete for using. Referring `read_existing_events` parameter to subscribe: #{bookmarkXml}"
+        log.warn "This stored bookmark is incomplete for using. Referring `read_existing_events` parameter to subscribe: #{bookmarkXml}, channel: #{channel}"
         false
       end
     end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -1,6 +1,7 @@
 require 'winevt'
 require 'fluent/plugin/input'
 require 'fluent/plugin'
+require_relative 'bookmark_sax_parser'
 
 module Fluent::Plugin
   class WindowsEventLog2Input < Input
@@ -113,12 +114,11 @@ module Fluent::Plugin
 
     def subscribe_channel(ch, read_existing_events)
       bookmarkXml = @bookmarks_storage.get(ch) || ""
+      bookmark = nil
+      if bookmark_validator(bookmarkXml, ch)
+        bookmark = Winevt::EventLog::Bookmark.new(bookmarkXml)
+      end
       subscribe = Winevt::EventLog::Subscribe.new
-      bookmark = unless bookmarkXml.empty?
-                   Winevt::EventLog::Bookmark.new(bookmarkXml)
-                 else
-                   nil
-                 end
       subscribe.read_existing_events = read_existing_events
       begin
         subscribe.subscribe(ch, "*", bookmark)
@@ -129,6 +129,21 @@ module Fluent::Plugin
       subscribe.rate_limit = @rate_limit
       timer_execute("in_windows_eventlog_#{escape_channel(ch)}".to_sym, @read_interval) do
         on_notify(ch, subscribe)
+      end
+    end
+
+    def bookmark_validator(bookmarkXml, channel)
+      return false if bookmarkXml.empty?
+
+      evtxml = WinevtBookmarkDocument.new
+      parser = Nokogiri::XML::SAX::Parser.new(evtxml)
+      parser.parse(bookmarkXml)
+      result = evtxml.result
+      if !result.empty? && (result[:channel] == channel) && result[:is_current]
+        true
+      else
+        log.warn "This stored bookmark is incomplete for using. Referring `read_existing_events` parameter to subscribe: #{bookmarkXml}"
+        false
       end
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,6 +25,7 @@ end
 require 'fluent/test/driver/input'
 require 'fluent/plugin/in_windows_eventlog'
 require 'fluent/plugin/in_windows_eventlog2'
+require 'fluent/plugin/bookmark_sax_parser'
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_bookmark_sax_parser.rb
+++ b/test/plugin/test_bookmark_sax_parser.rb
@@ -1,0 +1,41 @@
+require_relative '../helper'
+
+class BookmarkSAXParserTest < Test::Unit::TestCase
+
+  def setup
+    @evtxml = WinevtBookmarkDocument.new
+    @parser = Nokogiri::XML::SAX::Parser.new(@evtxml)
+  end
+
+  def test_parse
+    bookmark_str = <<EOS
+<BookmarkList>
+  <Bookmark Channel='Application' RecordId='161332' IsCurrent='true'/>
+</BookmarkList>
+EOS
+    @parser.parse(bookmark_str)
+    expected = {channel: "Application", record_id: 161332, is_current: true}
+    assert_equal expected, @evtxml.result
+  end
+
+  def test_parse_2
+    bookmark_str = <<EOS
+<BookmarkList>
+  <Bookmark Channel='Security' RecordId='25464' IsCurrent='true'/>
+</BookmarkList>
+EOS
+    @parser.parse(bookmark_str)
+    expected = {channel: "Security", record_id: 25464, is_current: true}
+    assert_equal expected, @evtxml.result
+  end
+
+  def test_parse_empty_bookmark_list
+    bookmark_str = <<EOS
+<BookmarkList>
+</BookmarkList>
+EOS
+    @parser.parse(bookmark_str)
+    expected = {}
+    assert_equal expected, @evtxml.result
+  end
+end

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -261,6 +261,7 @@ DESC
                                config_element("storage", "", {
                                                 '@type' => 'local',
                                                 '@id' => 'test-02',
+                                                '@log_level' => "info",
                                                 'path' => File.join(TEST_PLUGIN_STORAGE_PATH,
                                                                     'json', 'test-02.json'),
                                                 'persistent' => true,
@@ -321,9 +322,22 @@ EOS
       assert File.exist?(File.join(TEST_PLUGIN_STORAGE_PATH, 'json', 'test-02.json'))
 
       d2 = create_driver(CONFIG2)
-      assert_raise(Fluent::ConfigError) do
-        d2.instance.start
-      end
+      d2.instance.start
+      assert_equal 1, d2.logs.grep(/This stored bookmark is incomplete for using. Referring `read_existing_events` parameter to subscribe:/).length
+    end
+
+    def test_start_with_empty_bookmark
+      invalid_storage_contents = <<-EOS
+<BookmarkList>\r\n</BookmarkList>
+EOS
+      d = create_driver(CONFIG2)
+      storage = d.instance.instance_variable_get(:@bookmarks_storage)
+      storage.put('application', invalid_storage_contents)
+      assert File.exist?(File.join(TEST_PLUGIN_STORAGE_PATH, 'json', 'test-02.json'))
+
+      d2 = create_driver(CONFIG2)
+      d2.instance.start
+      assert_equal 1, d2.logs.grep(/This stored bookmark is incomplete for using. Referring `read_existing_events` parameter to subscribe:/).length
     end
   end
 

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -322,8 +322,10 @@ EOS
       assert File.exist?(File.join(TEST_PLUGIN_STORAGE_PATH, 'json', 'test-02.json'))
 
       d2 = create_driver(CONFIG2)
-      d2.instance.start
-      assert_equal 1, d2.logs.grep(/This stored bookmark is incomplete for using. Referring `read_existing_events` parameter to subscribe:/).length
+      assert_raise(Fluent::ConfigError) do
+        d2.instance.start
+      end
+      assert_equal 0, d2.logs.grep(/This stored bookmark is incomplete for using. Referring `read_existing_events` parameter to subscribe:/).length
     end
 
     def test_start_with_empty_bookmark


### PR DESCRIPTION
Related to #40.
We should do more validating Bookmark XML string before creating Bookmark object with `Winevt::EventLog::Bookmark.new`.