### PR TITLE
Read from all channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`read_from_head`   | **Deprecated** (option) Start to read the entries from the oldest, not from when fluentd is started. Defaults to `false`.|
 |`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|
 |`rate_limit`      | (option) Specify rate limit to consume EventLog. Default is `Winevt::EventLog::Subscribe::RATE_INFINITE`.|
-|`read_all_channels`| (option) Read from all channels|
+|`read_all_channels`| (option) Read from all channels. Default is `false`|
 |`<subscribe>`          | Setting for subscribe channels. |
 
 ##### subscribe section

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`parse_description`| (option) parse `description` field and set parsed result into the record. `Description` and `EventData` fields are removed|
 |`read_from_head`   | **Deprecated** (option) Start to read the entries from the oldest, not from when fluentd is started. Defaults to `false`.|
 |`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|
-|`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|
 |`rate_limit`      | (option) Specify rate limit to consume EventLog. Default is `Winevt::EventLog::Subscribe::RATE_INFINITE`.|
+|`read_all_channels`| (option) Read from all channels|
 |`<subscribe>`          | Setting for subscribe channels. |
 
 ##### subscribe section

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.2.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"
-  spec.add_runtime_dependency "winevt_c", ">= 0.7.0"
+  spec.add_runtime_dependency "winevt_c", ">= 0.7.1"
   spec.add_runtime_dependency "nokogiri", "~> 1.10"
   spec.add_runtime_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
 end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -76,7 +76,7 @@ module Fluent::Plugin
       end
           
       @read_existing_events = @read_from_head || @read_existing_events
-      if @channels.empty? && @subscribe_configs.empty?
+      if @channels.empty? && @subscribe_configs.empty? && !read_all_channels
         @chs.push(['application', @read_existing_events])
       else
         @channels.map {|ch| ch.strip.downcase }.uniq.each do |uch|

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -69,14 +69,14 @@ module Fluent::Plugin
       @chs = []
       @all_chs = Winevt::EventLog::Channel.new
 
-      if read_all_channels
+      if @read_all_channels
         @allChs.each do |allChs|
           @chs.push(allChs)
         end
       end
           
       @read_existing_events = @read_from_head || @read_existing_events
-      if @channels.empty? && @subscribe_configs.empty? && !read_all_channels
+      if @channels.empty? && @subscribe_configs.empty? && !@read_all_channels
         @chs.push(['application', @read_existing_events])
       else
         @channels.map {|ch| ch.strip.downcase }.uniq.each do |uch|

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -71,11 +71,12 @@ module Fluent::Plugin
       @all_chs.force_enumerate = false
 
       if @read_all_channels
-        @all_chs.each do |all_chs|
-          @chs.push(all_chs)
+        @all_chs.each do |ch|
+          uch = ch.strip.downcase
+          @chs.push([uch, @read_existing_events])
         end
       end
-          
+
       @read_existing_events = @read_from_head || @read_existing_events
       if @channels.empty? && @subscribe_configs.empty? && !@read_all_channels
         @chs.push(['application', @read_existing_events])

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -40,7 +40,7 @@ module Fluent::Plugin
     config_param :parse_description, :bool, default: false
     config_param :render_as_xml, :bool, default: true
     config_param :rate_limit, :integer, default: Winevt::EventLog::Subscribe::RATE_INFINITE
-    config_param :read_all_channels, :bool, default: true
+    config_param :read_all_channels, :bool, default: false
 
     config_section :subscribe, param_name: :subscribe_configs, required: false, multi: true do
       config_param :channels, :array

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -116,11 +116,7 @@ module Fluent::Plugin
       super
 
       @chs.each do |ch, read_existing_events|
-        if (read_all_channels)
-          subscribe_channel(ch, read_existing_events) rescue ''
-        else 
-          subscribe_channel(ch, read_existing_events)
-        end
+        subscribe_channel(ch, read_existing_events)
       end
     end
 

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -68,10 +68,11 @@ module Fluent::Plugin
       super
       @chs = []
       @all_chs = Winevt::EventLog::Channel.new
+      @all_chs.force_enumerate = false
 
       if @read_all_channels
-        @allChs.each do |allChs|
-          @chs.push(allChs)
+        @all_chs.each do |all_chs|
+          @chs.push(all_chs)
         end
       end
           

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -67,7 +67,7 @@ module Fluent::Plugin
     def configure(conf)
       super
       @chs = []
-      @allChs = Winevt::EventLog::Channel.new
+      @all_chs = Winevt::EventLog::Channel.new
 
       if read_all_channels
         @allChs.each do |allChs|


### PR DESCRIPTION
Adding an optional feature to read from all channels. As some of the channels its gets from `Winevt::EventLog::Channel.new` is not working to subscribe to. Fix for that is simply just a rescue to remove those that does not work as those really dont exist. More info at https://github.com/fluent/fluent-plugin-windows-eventlog/issues/47

Maybe change name to subscribe_to_all_channels or something.