### PR TITLE
in_windows_eventlog: Add a deprecated warning

### DIFF
--- a/lib/fluent/plugin/in_windows_eventlog.rb
+++ b/lib/fluent/plugin/in_windows_eventlog.rb
@@ -49,6 +49,7 @@ module Fluent::Plugin
     end
 
     def configure(conf)
+      log.warn "in_windows_eventlog is deprecated. It will be removed in the future version."
       super
       @chs = @channels.map {|ch| ch.strip.downcase }.uniq
       if @chs.empty?


### PR DESCRIPTION
https://github.com/fluent/fluent-plugin-windows-eventlog/issues/44#issuecomment-593753867

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>