### PR TITLE
Handle preserve_qualifiers option to provide preserving "Qualifiers" key choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       tag winevt.raw
       render_as_xml false       # default is true.
       rate_limit 200            # default is -1(Winevt::EventLog::Subscribe::RATE_INFINITE).
+      # preserve_qualifiers_on_hash true # default is false.
       <storage>
         @type local             # @type local is the default.
         persistent true         # default is true. Set to false to use in-memory storage.
@@ -149,6 +150,11 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       </storage>
       <parse>
         @type winevt_xml # @type winevt_xml is the default. winevt_xml and none parsers are supported for now.
+        # When set up it as true, this plugin preserves "Qualifiers" and "EventID" keys.
+        # When set up it as false, this plugin calculates actual "EventID" from "Qualifiers" and removing "Qualifiers".
+        # With the following equation:
+        # (EventID & 0xffff) | (Qualifiers & 0xffff) << 16
+        preserve_qualifiers true
       </parse>
       # <subscribe>
       #   channles application, system
@@ -177,7 +183,9 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`parse_description`| (option) parse `description` field and set parsed result into the record. `Description` and `EventData` fields are removed|
 |`read_from_head`   | **Deprecated** (option) Start to read the entries from the oldest, not from when fluentd is started. Defaults to `false`.|
 |`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|
+|`render_as_xml` | (option) Render Windows EventLog as XML or Ruby Hash object directly. Defaults to `true`.|
 |`rate_limit`      | (option) Specify rate limit to consume EventLog. Default is `Winevt::EventLog::Subscribe::RATE_INFINITE`.|
+|`preserve_qualifiers_on_hash`      | (option) When set up it as true, this plugin preserves "Qualifiers" and "EventID" keys. When set up it as false, this plugin calculates actual "EventID" from "Qualifiers" and removing "Qualifiers". Default is `false`.|
 |`read_all_channels`| (option) Read from all channels. Default is `false`|
 |`<subscribe>`          | Setting for subscribe channels. |
 

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -113,6 +113,9 @@ module Fluent::Plugin
         end
       end
 
+      if @render_as_xml && @preserve_qualifiers_on_hash
+        raise Fluent::ConfigError, "preserve_qualifiers_on_hash must be used with Hash object rendering(render_as_xml as false)."
+      end
       if !@render_as_xml && !@preserve_qualifiers_on_hash
         @keynames.delete('Qualifiers')
       elsif @parser.respond_to?(:preserve_qualifiers?) && !@parser.preserve_qualifiers?

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -95,8 +95,6 @@ module Fluent::Plugin
       if @keynames.empty?
         @keynames = KEY_MAP.keys
       end
-      @keynames.delete('Qualifiers') unless @render_as_xml
-      @keynames.delete('EventData') if @parse_description
 
       @tag = tag
       @bookmarks_storage = storage_create(usage: "bookmarks")
@@ -112,6 +110,13 @@ module Fluent::Plugin
           alias_method :on_notify, :on_notify_hash
         end
       end
+
+      if !@render_as_xml
+        @keynames.delete('Qualifiers')
+      elsif @parser.respond_to?(:preserve_qualifiers?) && !@parser.preserve_qualifiers?
+        @keynames.delete('Qualifiers')
+      end
+      @keynames.delete('EventData') if @parse_description
     end
 
     def start

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -89,6 +89,20 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
       assert_equal 2, d.instance.instance_variable_get(:@chs).select {|ch, flag| ch == "system"}.size
       assert_equal expected, d.instance.instance_variable_get(:@chs)
     end
+
+    test "invalid combination for preserving qualifiers" do
+      assert_raise(Fluent::ConfigError) do
+        create_driver config_element("ROOT", "", {"tag" => "fluent.eventlog",
+                                                  "render_as_xml" => true,
+                                                  "preserve_qualifiers_on_hash" => true,
+                                                 }, [
+                                       config_element("storage", "", {
+                                                        '@type' => 'local',
+                                                        'persistent' => false
+                                                      }),
+                                     ])
+      end
+    end
   end
 
   data("application"        => ["Application", "Application"],

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -372,4 +372,33 @@ EOS
     assert_true(record.has_key?("Description"))
     assert_true(record.has_key?("EventData"))
   end
+
+  def test_write_with_winevt_xml_parser_without_qualifiers
+    d = create_driver(config_element("ROOT", "", {"tag" => "fluent.eventlog"}, [
+                                       config_element("storage", "", {
+                                                        '@type' => 'local',
+                                                        'persistent' => false
+                                                      }),
+                                       config_element("parse", "", {
+                                                        '@type' => 'winevt_xml',
+                                                        'preserve_qualifiers' => false
+                                                      }),
+                                     ]))
+
+    service = Fluent::Plugin::EventService.new
+
+    omit "@parser.preserve_qualifiers does not respond" unless d.instance.instance_variable_get(:@parser).respond_to?(:preserve_qualifiers?)
+
+    d.run(expect_emits: 1) do
+      service.run
+    end
+
+    assert(d.events.length >= 1)
+    event = d.events.last
+    record = event.last
+
+    assert_true(record.has_key?("Description"))
+    assert_true(record.has_key?("EventData"))
+    assert_false(record.has_key?("Qualifiers"))
+  end
 end


### PR DESCRIPTION
We should provide preserve_qualifiers option to provide preserving "Qualifiers" key choice.

Currently, EventID representation is:

* EventID which is the lower int16 value and QUalifiers which is the higher int16 value.
  * EventID | Qualifiers << 16
* EventID which is calculated from EventID which is the lower int16 value and QUalifiers which is the higher int16 value.
  * EventID (which is long type and actual value)

They have same meaning and value but representation differs.
So, we should provide Qualifiers handling option.

On direct hash mapping case, we can handle it with the following configuration parameters:

* **render_as_xml** as **false**
* **preserve_qualifiers_on_hash** as **true**

Then, rendered as XML case is:

* **render_as_xml** as **true**
* **preserve_qualifiers** as **true** within `<parse>` directive.

