### PR TITLE
in_windows_eventlog2: Add method existence checker

### DIFF
--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -142,7 +142,7 @@ module Fluent::Plugin
       subscribe.read_existing_events = read_existing_events
       begin
         subscribe.subscribe(ch, "*", bookmark)
-        if !@render_as_xml && @preserve_qualifiers_on_hash && subscribe.respond_to?(:preserve_qualifiers?)
+        if !@render_as_xml && @preserve_qualifiers_on_hash && subscribe.respond_to?(:preserve_qualifiers=)
           subscribe.preserve_qualifiers = @preserve_qualifiers_on_hash
         end
       rescue Winevt::EventLog::Query::Error => e

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -142,7 +142,7 @@ module Fluent::Plugin
       subscribe.read_existing_events = read_existing_events
       begin
         subscribe.subscribe(ch, "*", bookmark)
-        if !@render_as_xml && @preserve_qualifiers_on_hash
+        if !@render_as_xml && @preserve_qualifiers_on_hash && subscribe.respond_to?(:preserve_qualifiers?)
           subscribe.preserve_qualifiers = @preserve_qualifiers_on_hash
         end
       rescue Winevt::EventLog::Query::Error => e


### PR DESCRIPTION
Because Subscribe#preserve_qualifiers= and Subscribe#preserve_qualifiers?
do not exist in older version of winevt_c.

Follows up #52.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>