### PR TITLE
Make XML rendering as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       read_existing_events false
       read_interval 2
       tag winevt.raw
-      render_as_xml false       # default is true.
+      render_as_xml false       # default is false.
       rate_limit 200            # default is -1(Winevt::EventLog::Subscribe::RATE_INFINITE).
       # preserve_qualifiers_on_hash true # default is false.
       <storage>
@@ -166,7 +166,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 
 **NOTE:** When `Description` contains error message such as `The message resource is present but the message was not found in the message table.`, eventlog's resource file (.mui) related to error generating event is something wrong. This issue is also occurred in built-in Windows Event Viewer which is the part of Windows management tool.
 
-**NOTE:** When `render_as_xml` as `false`, the dependent winevt_c gem renders Windows EventLog as Ruby Hash object directly. This reduces bottleneck to consume EventLog. Specifying `render_as_xml` as `false` should be faster consuming than `render_as_xml` as `true` case.
+**NOTE:** When `render_as_xml` as `true`, `fluent-plugin-parser-winevt_xml` plugin should be needed to parse XML rendered Windows EventLog string.
 
 **NOTE:** If you encountered CPU spike due to massively huge EventLog channel, `rate_limit` parameter may help you. Currently, this paramter can handle the multiples of 10 or -1(`Winevt::EventLog::Subscribe::RATE_INFINITE`).
 
@@ -183,7 +183,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`parse_description`| (option) parse `description` field and set parsed result into the record. `Description` and `EventData` fields are removed|
 |`read_from_head`   | **Deprecated** (option) Start to read the entries from the oldest, not from when fluentd is started. Defaults to `false`.|
 |`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`.|
-|`render_as_xml` | (option) Render Windows EventLog as XML or Ruby Hash object directly. Defaults to `true`.|
+|`render_as_xml` | (option) Render Windows EventLog as XML or Ruby Hash object directly. Defaults to `false`.|
 |`rate_limit`      | (option) Specify rate limit to consume EventLog. Default is `Winevt::EventLog::Subscribe::RATE_INFINITE`.|
 |`preserve_qualifiers_on_hash`      | (option) When set up it as true, this plugin preserves "Qualifiers" and "EventID" keys. When set up it as false, this plugin calculates actual "EventID" from "Qualifiers" and removing "Qualifiers". Default is `false`.|
 |`read_all_channels`| (option) Read from all channels. Default is `false`|

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.2.0"
+  spec.add_development_dependency "nokogiri", [">= 1.10", "< 1.12"]
+  spec.add_development_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"
   spec.add_runtime_dependency "winevt_c", ">= 0.7.1"
-  spec.add_runtime_dependency "nokogiri", [">= 1.10", "< 1.12"]
-  spec.add_runtime_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
 end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -38,7 +38,7 @@ module Fluent::Plugin
     config_param :read_from_head, :bool, default: false, deprecated: "Use `read_existing_events' instead."
     config_param :read_existing_events, :bool, default: false
     config_param :parse_description, :bool, default: false
-    config_param :render_as_xml, :bool, default: true
+    config_param :render_as_xml, :bool, default: false
     config_param :rate_limit, :integer, default: Winevt::EventLog::Subscribe::RATE_INFINITE
     config_param :preserve_qualifiers_on_hash, :bool, default: false
     config_param :read_all_channels, :bool, default: false

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -15,6 +15,14 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
                                            })
                           ])
 
+  XML_RENDERING_CONFIG = config_element("ROOT", "", {"tag" => "fluent.eventlog",
+                                                     "render_as_xml" => true}, [
+                                          config_element("storage", "", {
+                                                           '@type' => 'local',
+                                                           'persistent' => false
+                                                         })
+                                        ])
+
   def create_driver(conf = CONFIG)
     Fluent::Test::Driver::Input.new(Fluent::Plugin::WindowsEventLog2Input).configure(conf)
   end
@@ -25,7 +33,7 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
     assert_equal 2, d.instance.read_interval
     assert_equal [], d.instance.channels
     assert_false d.instance.read_existing_events
-    assert_true d.instance.render_as_xml
+    assert_false d.instance.render_as_xml
   end
 
   sub_test_case "configure" do
@@ -389,7 +397,8 @@ EOS
   end
 
   def test_write_with_none_parser
-    d = create_driver(config_element("ROOT", "", {"tag" => "fluent.eventlog"}, [
+    d = create_driver(config_element("ROOT", "", {"tag" => "fluent.eventlog",
+                                                  "render_as_xml" => true}, [
                                        config_element("storage", "", {
                                                         '@type' => 'local',
                                                         'persistent' => false
@@ -419,7 +428,8 @@ EOS
   end
 
   def test_write_with_winevt_xml_parser_without_qualifiers
-    d = create_driver(config_element("ROOT", "", {"tag" => "fluent.eventlog"}, [
+    d = create_driver(config_element("ROOT", "", {"tag" => "fluent.eventlog",
+                                                  "render_as_xml" => true}, [
                                        config_element("storage", "", {
                                                         '@type' => 'local',
                                                         'persistent' => false


### PR DESCRIPTION
XML rendering should be turn off by default.

1. Rendered XML string should be parsed with XML parser such as nokogiri,
but it makes additional dependency for nokogiri.
2. Direct Hash rendering is lower cost than rendering Windows EventLog as XML.

So, we should make render_as_xml as false by default.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>