### PR TITLE
Allow to install nokogiri 1.11 rc version

### DIFF
--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.2.0"
-  spec.add_development_dependency "nokogiri", [">= 1.10", "< 1.12"]
+  spec.add_development_dependency "nokogiri", [">= 1.10", "~> 1.11.pre"]
   spec.add_development_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.2.0"
-  spec.add_development_dependency "nokogiri", [">= 1.10", "~> 1.11.pre"]
+  spec.add_development_dependency "nokogiri", [">= 1.11.pre", "< 1.12"]
   spec.add_development_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"


### PR DESCRIPTION
It fixes the following error:

  ERROR: Error installing
  C:/td-agent-4.0.0~rc1/td-agent/downloads/plugin_gems/26-fluent-plugin-windows-eventlog-0.5.4.gem:
  The last version of nokogiri (>= 1.10, < 1.12) to support your Ruby
  & RubyGems was 1.10.9. Try installing it with `gem install nokogiri
  -v 1.10.9` and then running the current command again nokogiri
  requires Ruby version >= 2.3, < 2.7.dev. The current ruby version is
  2.7.1.83.  rake aborted!

Signed-off-by: Kentaro Hayashi <kenhys@gmail.com>