### PR TITLE
Support remoting access parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       # <subscribe>
       #   channles application, system
       #   read_existing_events false # read_existing_events should be applied each of subscribe directive(s)
+      #   remote_server 127.0.0.1 # Remote server ip/fqdn
+      #   remote_domain WORKGROUP # Domain name
+      #   remote_username fluentd # Remoting access account name
+      #   remote_password changeme! # Remoting access account password
       # </subscribe>
     </source>
 
@@ -198,6 +202,10 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |:-----    |:-----       |
 |`channels`             | One or more of {'application', 'system', 'setup', 'security'}. If you want to read 'setup' or 'security' logs, you must launch fluentd with administrator privileges. |
 |`read_existing_events` | (option) Read the entries which already exist before fluentd is started. Defaults to `false`. |
+|`remote_server` | (option) Remoting access server ip address/fqdn. Defaults to `nil`. |
+|`remote_domain` | (option) Remoting access server joining domain name. Defaults to `nil`. |
+|`remote_username` | (option) Remoting access access account's username. Defaults to `nil`. |
+|`remote_password` | (option) Remoting access access account's password. Defaults to `nil`. |
 
 
 **Motivation:** subscribe directive is designed for applying `read_existing_events` each of channels which is specified in subscribe section(s).
@@ -233,6 +241,33 @@ This configuration can be handled as:
 
 * "Application" and "Security" channels just tailing
 * "HardwareEvent" channel read existing events before launching Fluentd
+
+###### Remoting access
+
+`<subscribe>` section supports remoting access parameters:
+
+* `remote_server`
+* `remote_domain`
+* `remote_username`
+* `remote_password`
+
+These parameters are only in `<subscribe>` directive.
+
+Note that before using this feature, remoting access users should belong to "Event Log Readers" group:
+
+```console
+> net localgroup "Event Log Readers" <domain\username> /add
+```
+
+And then, users also should set up their remote box's Firewall configuration:
+
+```console
+> netsh advfirewall firewall set rule group="Remote Event Log Management" new enable=yes
+```
+
+As a security best practices, remoting access account _should not be administrator account_.
+
+For graphical instructions, please refer to [Preconfigure a Machine to Collect Remote Windows Events | Sumo Logic](https://help.sumologic.com/03Send-Data/Sources/01Sources-for-Installed-Collectors/Remote-Windows-Event-Log-Source/Preconfigure-a-Machine-to-Collect-Remote-Windows-Events) document for example.
 
 ##### Available keys
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       # preserve_qualifiers_on_hash true # default is false.
       # read_all_channels false # default is false.
       # description_locale en_US # default is nil. It means that system locale is used for obtaining description.
+      # refresh_subscription_interval 60s # default is nil. It specifies refresh interval for channel subscriptions.
       <storage>
         @type local             # @type local is the default.
         persistent true         # default is true. Set to false to use in-memory storage.
@@ -194,6 +195,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`preserve_qualifiers_on_hash`      | (option) When set up it as true, this plugin preserves "Qualifiers" and "EventID" keys. When set up it as false, this plugin calculates actual "EventID" from "Qualifiers" and removing "Qualifiers". Default is `false`.|
 |`read_all_channels`| (option) Read from all channels. Default is `false`|
 |`description_locale`| (option) Specify description locale. Default is `nil`. See also: [Supported locales](https://github.com/fluent-plugins-nursery/winevt_c#multilingual-description) |
+|`refresh_subscription_interval`|(option) It specifies refresh interval for channel subscriptions. Default is `nil`.|
 |`<subscribe>`          | Setting for subscribe channels. |
 
 ##### subscribe section

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       # preserve_qualifiers_on_hash true # default is false.
       # read_all_channels false # default is false.
       # description_locale en_US # default is nil. It means that system locale is used for obtaining description.
-      # refresh_subscription_interval 60s # default is nil. It specifies refresh interval for channel subscriptions.
+      # refresh_subscription_interval 10m # default is nil. It specifies refresh interval for channel subscriptions.
       <storage>
         @type local             # @type local is the default.
         persistent true         # default is true. Set to false to use in-memory storage.

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"
-  spec.add_runtime_dependency "winevt_c", ">= 0.9.0"
+  spec.add_runtime_dependency "winevt_c", ">= 0.9.1"
 end

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.2.0"
-  spec.add_development_dependency "nokogiri", [">= 1.11.pre", "< 1.12"]
+  spec.add_development_dependency "nokogiri", [">= 1.10", "< 1.12"]
   spec.add_development_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"

--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"
-  spec.add_runtime_dependency "winevt_c", ">= 0.8.1"
+  spec.add_runtime_dependency "winevt_c", ">= 0.9.0"
 end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -190,10 +190,22 @@ module Fluent::Plugin
     end
 
     def clear_subscritpions
-      @subscriptions.clear
-      @timers.each do |ch, timer|
-        event_loop_detach(timer)
-        log.debug "channel (#{ch}) subscription is detached."
+      @subscriptions.keys.each do |ch|
+        subscription = @subscriptions.delete(ch)
+        if subscription
+          if subscription.cancel
+            log.debug "channel (#{ch}) subscription is cancelled."
+            subscription.close
+            log.debug "channel (#{ch}) subscription handles are closed forcibly."
+          end
+        end
+      end
+      @timers.keys.each do |ch|
+        timer = @timers.delete(ch)
+        if timer
+          event_loop_detach(timer)
+          log.debug "channel (#{ch}) subscription watcher is detached."
+        end
       end
     end
 

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -308,12 +308,12 @@ module Fluent::Plugin
             end
           end
         end
+        router.emit_stream(@tag, es)
+        @bookmarks_storage.put(ch, subscribe.bookmark)
       rescue Winevt::EventLog::Query::Error => e
-        log.warn "Invalid XML data", error: e
+        log.warn "Invalid XML data on #{ch}.", error: e
         log.warn_backtrace
       end
-      router.emit_stream(@tag, es)
-      @bookmarks_storage.put(ch, subscribe.bookmark)
     end
 
     def on_notify_hash(ch, subscribe)
@@ -338,12 +338,12 @@ module Fluent::Plugin
           parse_desc(h) if @parse_description
           es.add(Fluent::Engine.now, h)
         end
+        router.emit_stream(@tag, es)
+        @bookmarks_storage.put(ch, subscribe.bookmark)
       rescue Winevt::EventLog::Query::Error => e
-        log.warn "Invalid Hash data", error: e
+        log.warn "Invalid Hash data on #{ch}.", error: e
         log.warn_backtrace
       end
-      router.emit_stream(@tag, es)
-      @bookmarks_storage.put(ch, subscribe.bookmark)
     end
 
     #### These lines copied from in_windows_eventlog plugin:

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -161,6 +161,18 @@ module Fluent::Plugin
       end
     end
 
+    def shutdown
+      super
+
+      @subscriptions.keys.each do |ch|
+        subscription = @subscriptions.delete(ch)
+        if subscription
+          subscription.cancel
+          log.debug "channel (#{ch}) subscription is canceled."
+        end
+      end
+    end
+
     def retry_on_error(channel, times: 15)
       try = 0
       begin

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -321,7 +321,7 @@ DESC
     end
 
     assert(d.events.length >= 1)
-    event = d.events.last
+    event = d.events.select {|e| e.last["EventID"] == "65500" }.last
     record = event.last
 
     expected = {"EventID"      => "65500",
@@ -353,7 +353,7 @@ DESC
     end
 
     assert(d.events.length >= 1)
-    event = d.events.last
+    event = d.events.select {|e| e.last["EventID"] == "65500" }.last
     record = event.last
 
     assert_equal("Application", record["Channel"])

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -45,9 +45,21 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
     assert_equal [], d.instance.channels
     assert_false d.instance.read_existing_events
     assert_false d.instance.render_as_xml
+    assert_nil d.instance.refresh_subscription_interval
   end
 
   sub_test_case "configure" do
+    test "refresh subscription interval" do
+      d = create_driver config_element("ROOT", "", {"tag" => "fluent.eventlog",
+                                                    "refresh_subscription_interval" => "2m"}, [
+                                         config_element("storage", "", {
+                                                          '@type' => 'local',
+                                                          'persistent' => false
+                                                        })
+                                       ])
+      assert_equal 120, d.instance.refresh_subscription_interval
+    end
+
     test "subscribe directive" do
       d = create_driver config_element("ROOT", "", {"tag" => "fluent.eventlog"}, [
                                          config_element("storage", "", {

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -51,7 +51,7 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
                                                           'read_existing_events' => true
                                                         }),
                                        ])
-      expected = [["system", false], ["windows powershell", false], ["security", true]]
+      expected = [["system", false, nil], ["windows powershell", false, nil], ["security", true, nil]]
       assert_equal expected, d.instance.instance_variable_get(:@chs)
     end
 
@@ -71,7 +71,7 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
                                                           'read_existing_events' => true
                                                         }),
                                        ])
-      expected = [["system", false], ["windows powershell", false], ["security", true]]
+      expected = [["system", false, nil], ["windows powershell", false, nil], ["security", true, nil]]
       assert_equal 1, d.instance.instance_variable_get(:@chs).select {|ch, flag| ch == "system"}.size
       assert_equal expected, d.instance.instance_variable_get(:@chs)
     end
@@ -93,7 +93,7 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
                                                           'read_existing_events' => true
                                                         }),
                                        ])
-      expected = [["system", false], ["windows powershell", false], ["system", true], ["windows powershell", true], ["security", true]]
+      expected = [["system", false, nil], ["windows powershell", false, nil], ["system", true, nil], ["windows powershell", true, nil], ["security", true, nil]]
       assert_equal 2, d.instance.instance_variable_get(:@chs).select {|ch, flag| ch == "system"}.size
       assert_equal expected, d.instance.instance_variable_get(:@chs)
     end


### PR DESCRIPTION
I'd implemented remoting access feature to retrieve remote Windows box.
But I noticed that remote session handle does not have keep alive or re-connecting feature.
Currently, we need to restart td-agent/fluentd's worker when re-connecting for remote Windows box.

Current Fluentd's implementation does not support reload RPC endpoint on Windows.
This should be needed to reload and reconstruct remote Windows box connection.
 