### PR TITLE
Support event query parameter on Windows EventLog channel subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
       # read_all_channels false # default is false.
       # description_locale en_US # default is nil. It means that system locale is used for obtaining description.
       # refresh_subscription_interval 10m # default is nil. It specifies refresh interval for channel subscriptions.
+      # event_query "Event/System[EventID!=1001]" # default is "*".
       <storage>
         @type local             # @type local is the default.
         persistent true         # default is true. Set to false to use in-memory storage.
@@ -196,6 +197,7 @@ fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`read_all_channels`| (option) Read from all channels. Default is `false`|
 |`description_locale`| (option) Specify description locale. Default is `nil`. See also: [Supported locales](https://github.com/fluent-plugins-nursery/winevt_c#multilingual-description) |
 |`refresh_subscription_interval`|(option) It specifies refresh interval for channel subscriptions. Default is `nil`.|
+|`event_query`|(option) It specifies query for deny/allow/filter events with XPath 1.0 or structured XML query. Default is `"*"` (retrieving all events).|
 |`<subscribe>`          | Setting for subscribe channels. |
 
 ##### subscribe section

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -46,6 +46,7 @@ module Fluent::Plugin
     config_param :read_all_channels, :bool, default: false
     config_param :description_locale, :string, default: nil
     config_param :refresh_subscription_interval, :time, default: nil
+    config_param :event_query, :string, default: "*"
 
     config_section :subscribe, param_name: :subscribe_configs, required: false, multi: true do
       config_param :channels, :array
@@ -230,7 +231,7 @@ module Fluent::Plugin
       subscribe = Winevt::EventLog::Subscribe.new
       subscribe.read_existing_events = read_existing_events
       begin
-        subscribe.subscribe(ch, "*", bookmark, remote_session)
+        subscribe.subscribe(ch, event_query, bookmark, remote_session)
         if !@render_as_xml && @preserve_qualifiers_on_hash
           subscribe.preserve_qualifiers = @preserve_qualifiers_on_hash
         end

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -302,6 +302,33 @@ DESC
     assert_equal("fluent-plugins", record["ProviderName"])
   end
 
+  CONFIG_WITH_QUERY = config_element("ROOT", "", {"tag" => "fluent.eventlog",
+                                                  "event_query" => "Event/System[EventID=65500]"}, [
+                                       config_element("storage", "", {
+                                                        '@type' => 'local',
+                                                        'persistent' => false
+                                                      })
+                          ])
+  def test_write_with_event_query
+    d = create_driver(CONFIG_WITH_QUERY)
+
+    service = Fluent::Plugin::EventService.new
+
+    d.run(expect_emits: 1) do
+      service.run
+    end
+
+    assert(d.events.length >= 1)
+    event = d.events.last
+    record = event.last
+
+    assert_equal("Application", record["Channel"])
+    assert_equal("65500", record["EventID"])
+    assert_equal("4", record["Level"])
+    assert_equal("fluent-plugins", record["ProviderName"])
+  end
+
+
   CONFIG_KEYS = config_element("ROOT", "", {
                                  "tag" => "fluent.eventlog",
                                  "keys" => ["EventID", "Level", "Channel", "ProviderName"]

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -495,8 +495,9 @@ DESC
         service.run
       end
 
-      assert(d2.events.length == 1) # should be tailing after previous context.
-      event2 = d2.events.last
+      events = d2.events.select {|e| e.last["EventID"] == "65500" }
+      assert(events.length == 1) # should be tailing after previous context.
+      event2 = events.last
       record2 = event2.last
 
       curr_id = record2["EventRecordID"].to_i


### PR DESCRIPTION
This feature should be needed for denying/allowing on #subscribe API for some specific EventID containing Windows EventLog that shouldn't be consumed with Windows EventLog plugin.
Currently, some EventID containing events are corrupted for consuming with this plugin.
We need to investigate about it further.
 
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>