### PR TITLE
in_windows_eventlog2: Skip to subscribe non-existent channel

### DIFF
--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"
-  spec.add_runtime_dependency "winevt_c", ">= 0.9.1"
+  spec.add_runtime_dependency "winevt_c", ">= 0.10.1"
 end

--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -195,8 +195,12 @@ module Fluent::Plugin
 
       @chs.each do |ch, read_existing_events, session|
         retry_on_error(ch) do
-          ch, subscribe = subscription(ch, read_existing_events, session)
-          @subscriptions[ch] = subscribe
+          begin
+            ch, subscribe = subscription(ch, read_existing_events, session)
+            @subscriptions[ch] = subscribe
+          rescue Winevt::EventLog::ChannelNotFoundError => e
+            log.warn "#{e.message}"
+          end
         end
       end
       subscribe_channels(@subscriptions)

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -302,6 +302,25 @@ DESC
     assert_equal("fluent-plugins", record["ProviderName"])
   end
 
+  CONFIG_WITH_NON_EXISTENT_CHANNEL = config_element("ROOT", "", {
+                                 "channels" => ["application", "NonExistentChannel"]
+                               })
+  def test_skip_non_existent_channel
+    d = create_driver(CONFIG + CONFIG_WITH_NON_EXISTENT_CHANNEL)
+
+    service = Fluent::Plugin::EventService.new
+
+    assert_nothing_raised do
+      d.run(expect_emits: 1) do
+        service.run
+      end
+    end
+
+    assert(d.events.length >= 1)
+    assert(d.logs.any?{|log| log.include?("[warn]: Channel Not Found: nonexistentchannel") },
+           d.logs.join("\n"))
+  end
+
   CONFIG_WITH_QUERY = config_element("ROOT", "", {"tag" => "fluent.eventlog",
                                                   "event_query" => "Event/System[EventID=65500]"}, [
                                        config_element("storage", "", {


### PR DESCRIPTION
in_windows_eventlog2 stops Fluentd with `Fluent::ConfigError` when a non-existent channel is specified. But it's not convenient since the channel might be added later.

This commit skips non-existent channels, just output warning log.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>