### PR TITLE
Remove `from_encoding` parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Fluentd Input plugin for the Windows Event Log using newer Windows Event Logging
 |`channels`         | (option) No default value just empty array, but 'application' is used as default due to backward compatibility. One or more of {'application', 'system', 'setup', 'security'} and other evtx, which is the brand new Windows XML Event Log (EVTX) format since Windows Vista, formatted channels. Theoritically, `in_windows_ventlog2` may read all of channels except for debug and analytical typed channels. If you want to read 'setup' or 'security' logs or some privileged channels, you must launch fluentd with administrator privileges.|
 |`keys`             | (option) A subset of [keys](#read-keys) to read. Defaults to all keys.|
 |`read_interval`    | (option) Read interval in seconds. 2 seconds as default.|
-|`from_encoding`    | (option) Input character encoding. `nil` as default.|
 |`<storage>`        | Setting for `storage` plugin for recording read position like `in_tail`'s `pos_file`.|
 |`<parse>`          | Setting for `parser` plugin for parsing raw XML EventLog records. |
 |`parse_description`| (option) parse `description` field and set parsed result into the record. `Description` and `EventData` fields are removed|


### PR DESCRIPTION
The `from_encoding` parameter was removed from the `in_windows_eventlog2` plugin in commit cddc2f42a771b0b2a1c834681346a429c0464f86 . However, this parameter is still present in the README. When using this parameter in a fluentd config, we get the warning:
```
warn: parameter 'from_encoding' in <source>...</source> is not used.
```

This PR removes the `from_encoding` parameter from the README to avoid confusion and prevent unnecessary warnings from showing up.