### PR TITLE
Not to load WinevtXMLparser by default

### DIFF
--- a/lib/fluent/plugin/in_windows_eventlog2.rb
+++ b/lib/fluent/plugin/in_windows_eventlog2.rb
@@ -64,7 +64,7 @@ module Fluent::Plugin
     end
 
     config_section :parse do
-      config_set_default :@type, 'winevt_xml'
+      config_set_default :@type, 'windows_eventlog2_dummy'
       config_set_default :estimate_current_event, false
     end
 
@@ -122,7 +122,12 @@ module Fluent::Plugin
       @winevt_xml = false
       @parser = nil
       if @render_as_xml
-        @parser = parser_create
+        parser_config = @parser_configs.first
+        if parser_config["@type"] == "windows_eventlog2_dummy"
+          @parser = parser_create(usage: "parse_xml", type: "winevt_xml", conf: conf.elements("parse").first)
+        else
+          @parser = parser_create
+        end
         @winevt_xml = @parser.respond_to?(:winevt_xml?) && @parser.winevt_xml?
         class << self
           alias_method :on_notify, :on_notify_xml
@@ -406,5 +411,17 @@ module Fluent::Plugin
       key
     end
     ####
+  end
+
+  class WindowsEventLog2DummyParser < Parser
+    Fluent::Plugin.register_parser('windows_eventlog2_dummy', self)
+
+    def configure(conf)
+      super
+    end
+
+    def parse(text)
+      raise NotImplementedError, "This is a dummy parser for the default setting and can not be used actually."
+    end
   end
 end

--- a/test/plugin/test_in_windows_eventlog2.rb
+++ b/test/plugin/test_in_windows_eventlog2.rb
@@ -176,6 +176,18 @@ class WindowsEventLog2InputTest < Test::Unit::TestCase
                                      ])
       end
     end
+
+    test "default parser should not be WinevtXMLparser" do
+      # Because it is not a mandatory dependency.
+      d = create_driver CONFIG
+      assert_equal 1, d.instance._parsers.size
+      assert_not_equal "Fluent::Plugin::WinevtXMLparser", d.instance._parsers.values.first.class.name
+    end
+
+    test "parser should be WinevtXMLparser if render_as_xml is enabled" do
+      d = create_driver XML_RENDERING_CONFIG
+      assert_equal Fluent::Plugin::WinevtXMLparser, d.instance.instance_variable_get(:@parser).class
+    end
   end
 
   data("Japanese"                => ["ja_JP", false],


### PR DESCRIPTION
`WinevtXMLparser` is not a mandatory dependency.
We need it only when enabling `render_as_xml`.

So, this plugin should not load it by default.
It can cause unintended NotFoundPluginError.

```
{datetime} [error]: config error file="xxx" error_class=Fluent::NotFoundPluginError
error="Unknown parser plugin 'winevt_xml'. Run 'gem search -rd fluent-plugin' to find plugins"
```
