### PR TITLE
Relax required Nokogiri version

### DIFF
--- a/fluent-plugin-winevtlog.gemspec
+++ b/fluent-plugin-winevtlog.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.4.0"
-  spec.add_development_dependency "nokogiri", [">= 1.10", "< 1.15"]
+  spec.add_development_dependency "nokogiri", "~> 1.10"
   spec.add_development_dependency "fluent-plugin-parser-winevt_xml", ">= 0.1.2"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
   spec.add_runtime_dependency "win32-eventlog"


### PR DESCRIPTION
* Nokogiri 1.18.2 (Ruby >= 3.1)
* Nokogiri 1.17.x (Ruby >= 3.0)
* Nokogiri 1.16.8 (Ruby >= 3.1)
* Nokogiri 1.16.7 (Ruby >= 3.0)

Passed:

Ruby 3.2 + Nokogiri 1.18.0
Ruby 3.1 + Nokogiri 1.16.8
Ruby 3.0 + Nokogiri 1.16.8
Ruby 2.7 + Nokogiri 1.15.7
